### PR TITLE
Only render comments if disqus_shortname is set

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,3 +1,4 @@
+{{ if isset .Site.Params "disqus_shortname" }}
 <div id="disqus_thread">
   <script type="text/javascript">
      var disqus_shortname = "{{ .Site.Params.disqus_shortname }}";
@@ -10,3 +11,4 @@
      })();
   </script>
 </div>
+{{ end }}


### PR DESCRIPTION
If the "disqus_shortname" Site Parameter isn't set, don't render the
disqus-related markup in the comments partial.