### PR TITLE
Page .URL deprecated v0.55,and found no layout for section

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -6,7 +6,7 @@
 
   <div>
    {{ $baseurl := .Site.BaseURL }}
-   {{ if eq .URL "/search/" }}
+   {{ if eq .Permalink "/search/" }}
 <link rel="stylesheet" type="text/css" href="{{ $baseurl }}/tipuesearch/tipuesearch.css">
 <script src="//ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.0/normalize.min.css">


### PR DESCRIPTION
under v 0.55 

` Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url`

`found no layout file for "HTML" for "section": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.`

this fixes it.