### PR TITLE
Fix listing pages for a specific tag

### DIFF
--- a/layouts/tag/tag.html
+++ b/layouts/tag/tag.html
@@ -5,7 +5,7 @@
     <div class="measure">
     <p>Tag: {{ .Title | lower }}</p>
     <ul>
-        {{ range .Site.RegularPages.ByDate.Reverse }}
+        {{ range .Pages.ByDate.Reverse }}
             <li><a href="{{ .Permalink}}"> {{ .LinkTitle }} </a></li>
         {{ end }}
     </ul>


### PR DESCRIPTION
Currently it lists all pages of the site instead of the pages for the specific tag.

This fixes #33 