### PR TITLE
Make author and tag being displayed dependent on them being available

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -5,7 +5,7 @@
     <div class="measure">
       <div class="post-header mb2">
         <h1 class="py2">{{ .Title }}</h1>
-        <span class="post-meta">{{ .Date.Format "Jan 2, 2006" }} by {{ .Params.author }}</span><br>
+        <span class="post-meta">{{ .Date.Format "Jan 2, 2006" }} {{ if isset .Params "author" }} by {{ .Params.author }} {{ end }}</span><br>
         {{ $baseurl := .Site.BaseURL }}
       </div>
 
@@ -13,12 +13,14 @@
       {{ .Content }}
       </article>
 
+      {{ if isset .Params "tags" }} {{ if len .Params.tags }}
       <p class="post-meta">{{ i18n "tags" }}:&nbsp;
         {{ range $i, $e := .Params.tags }}
             {{if $i}},&nbsp;{{end}}
             <a href="{{ $baseurl }}{{ $.Site.LanguagePrefix }}/tags/{{ . }}">{{ . }}</a>
         {{ end }}
       </p>
+      {{ end }} {{ end }}
 
       {{ partial "comments.html" . }}
     </div>

--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -1,15 +1,17 @@
 <div class="post">
   <a class="post-link" href="{{ .Permalink }}">
   <p class="post-meta left">{{ .Date.Format "Jan 2, 2006" }}</p>
-  <p class="post-author right">{{ i18n "written" }} {{ .Params.author }}</p>
+  {{ if isset .Params "author" }}<p class="post-author right">{{ i18n "written" }} {{ .Params.author }}</p>{{ end }}
   <div class="clearfix"></div>
   <h3 class="h2 post-title">{{ .Title }} {{ if .Draft }}(draft){{end}}</h3>
   <p class="post-summary">{{ .Summary }}</p>
   </a>
   {{ $baseurl := .Site.BaseURL }}
+  {{ if isset .Params "tags" }} {{ if len .Params.tags }}
   <p class="post-meta">{{ i18n "tags" }}:&nbsp;
   {{ range $i, $e := .Params.tags }}
       {{if $i}},&nbsp;{{end}}
       <a href="{{ $baseurl }}{{ $.Site.LanguagePrefix }}/tags/{{ . }}">{{ . }}</a>
   {{ end }}</p>
+  {{ end }}{{ end }}
 </div>


### PR DESCRIPTION
Currently author an tags are displayed regardless of them being available; this change makes it conditional based on them having a value.