### PR TITLE
Include tipuesearch CSS if search engine is enabled

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -25,7 +25,7 @@
   <link rel='stylesheet' type='text/css' href='//fonts.googleapis.com/css?family=Lato:900,300'> -->
 
   <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/combined-min.css">
-  <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/tipuesearch/tipuesearch.css">
+  {{ if isset .Site.Params "search_engine" }}<link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/tipuesearch/tipuesearch.css">{{ end }}
 
 </head>
 <body class="">


### PR DESCRIPTION
Right now the search CSS is included even if search is disabled. This change ensures search is only rendered if search is enabled.