### PR TITLE
Fixed improperly closed tag in search form

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -12,5 +12,5 @@
 <form class="navbar-search" action="{{ .Site.BaseURL }}/search/index.html"
     onsubmit="return validateForm(this.elements['q'].value);">
     <input type="text" class="search-query" placeholder="{{ i18n "search" }}" name="q" id="tipue_search_input">
-{{ end }}
 </form>
+{{ end }}


### PR DESCRIPTION
Setting 
```
[params]
  search_engine = false
```
Search input disappeared, but form close tag was present.
This PR just move closing tag in if statement.
![image](https://user-images.githubusercontent.com/33955091/73274286-00395280-41ee-11ea-8d54-4218c6452fac.png)
