### PR TITLE
adding baseurl to tags page links

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -30,7 +30,7 @@ $(document).ready(function() {
    <h3 id="title">{{ .Title }}</h3>
    {{ $data := .Data }}
     {{ range $key,$value := .Data.Terms.ByCount }}
-    <a href="{{ "/" | absLangURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} <br>
+    <a href="{{ $baseurl }}{{ "/" | relLangURL }}{{ $data.Plural }}/{{ $value.Name | urlize }}"> {{ $value.Name }} </a> {{ $value.Count }} <br>
     {{ end }}
     {{ end }}
   </div>


### PR DESCRIPTION
This is a pull request fixes https://github.com/azmelanar/hugo-theme-pixyll/issues/47

It edits https://github.com/azmelanar/hugo-theme-pixyll/blob/master/layouts/_default/terms.html#L33 by prepending `$baseurl` to the links from the Tags page, and changing `absLangURL` to `relLangURL`.

This allows the tags page links to work properly when the site BaseURL has the format `<domain>/<project>`, while preserving the multi-lingual functionality in the example site.