### PR TITLE
Update deprecated function ".Site.IsMultiLingual" to "hugo.IsMultilingual"

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -1,7 +1,7 @@
 <a href="{{ .Site.BaseURL }}{{ .Site.LanguagePrefix }}/about/">{{ i18n "about" }}</a>
 <a href="{{ .Site.BaseURL }}{{ .Site.LanguagePrefix }}/tags/">{{ i18n "tags" }}</a>
 <a href="{{ .Site.BaseURL }}{{ .Site.LanguagePrefix }}/contact/">{{ i18n "contact" }}</a>
-{{- if .Site.IsMultiLingual -}}
+{{- if hugo.IsMultilingual -}}
 {{- range $lang := .Site.Languages -}}
 {{- if ne $.Site.Language $lang -}}
 <a href="/{{ $lang }}">{{ $lang }}</a>


### PR DESCRIPTION
Fixes build error in v0.136.5. 

The function ".Site.IsMultiLingual" was deprecated in v0.124.0 and replaced with "hugo.IsMultilingual". 

Just a linguistic change.

`ERROR deprecated: .Site.IsMultiLingual was deprecated in Hugo v0.124.0 and will be removed in Hugo 0.137.0. Use hugo.IsMultilingual instead.`

